### PR TITLE
Feature: Fix eteam tag on PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,4 +27,4 @@ Other checklist (remove once completed):
 - [ ] Add the correct label to the PR
 - [ ] If change was for a bylaw or amendment, make sure to create a new release after merging into master according to the format specified in the [README](https://github.com/calblueprint/constitution#releases)
 
-CC: @eteam
+CC: @calblueprint/eteam


### PR DESCRIPTION
* Change the CC tag on the pull request template to correctly tag calblueprint/eteam
