### PR TITLE
Feature: Fix Blueprint full name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Constitution of Blueprint, Technology for Non-Profits
+# The Constitution of Blueprint, Technology for Nonprofits
 
 The documents [`Current_Constitution.md`](Current_Constitution.md) and [`Current_Bylaws.md`](Current_Bylaws.md) shall be the source of truth for Blueprint's Constitution and Bylaws. Should there be any discrepancies between the markdown and PDF versions, the markdown version should be referenced.
 


### PR DESCRIPTION
# Feature
- Fixed Blueprint full name to use Nonprofits instead of Non-Profits