### PR TITLE
Feature: Update ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/convertFiles.yml
+++ b/.github/workflows/convertFiles.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   convert:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
# Feature

Per https://github.com/actions/runner-images/issues/6002, ubuntu version 18.04 has been deprecated on github actions for a while. This PR bumps Ubuntu to 22.04 to fix the action used in converting the constitution to PDF format.  

CC: @calblueprint/eteam
